### PR TITLE
fix: better sync settings and better reporting

### DIFF
--- a/packages/client/src/layers/network/config.ts
+++ b/packages/client/src/layers/network/config.ts
@@ -40,4 +40,7 @@ export const getNetworkConfig: (networkConfig: GameConfig) => SetupContractConfi
   worldAddress: config.worldAddress,
   devMode: config.devMode,
   blockExplorer: config.blockExplorer,
+  cacheAgeThreshold: 600,
+  cacheInterval: 100,
+  limitEventsPerSecond: 40_000,
 });

--- a/packages/client/src/layers/network/createNetworkLayer.ts
+++ b/packages/client/src/layers/network/createNetworkLayer.ts
@@ -6,12 +6,11 @@ import {
   getComponentValue,
   HasValue,
   runQuery,
-  updateComponent,
 } from "@latticexyz/recs";
 import { setupDevSystems } from "./setup";
 import { createActionSystem, setupMUDNetwork, waitForActionCompletion } from "@latticexyz/std-client";
 import { GameConfig, getNetworkConfig } from "./config";
-import { awaitPromise, computedToStream, Coord, deferred, filterNullishValues, VoxelCoord } from "@latticexyz/utils";
+import { awaitPromise, computedToStream, Coord, filterNullishValues, VoxelCoord } from "@latticexyz/utils";
 import { BigNumber, utils, Signer } from "ethers";
 import {
   definePositionComponent,

--- a/packages/client/src/layers/react/components/LoadingState.tsx
+++ b/packages/client/src/layers/react/components/LoadingState.tsx
@@ -3,6 +3,8 @@ import { BootScreen, registerUIComponent } from "../engine";
 import { concat, map } from "rxjs";
 import { getComponentValue } from "@latticexyz/recs";
 import { GodID, SyncState } from "@latticexyz/network";
+import styled from "styled-components";
+import { LoadingBar } from "./common";
 
 export function registerLoadingState() {
   registerUIComponent(
@@ -36,10 +38,32 @@ export function registerLoadingState() {
       }
 
       if (loadingState.state !== SyncState.LIVE) {
-        return <BootScreen initialOpacity={1}>{loadingState.msg}</BootScreen>;
+        return (
+          <BootScreen initialOpacity={1}>
+            {loadingState.msg}
+            <LoadingContainer>
+              {loadingState.percentage}%<Loading percentage={loadingState.percentage} />
+            </LoadingContainer>
+          </BootScreen>
+        );
       }
 
       return null;
     }
   );
 }
+
+const LoadingContainer = styled.div`
+  display: grid;
+  justify-items: start;
+  justify-content: start;
+  align-items: center;
+  height: 30px;
+  width: 100%;
+  grid-gap: 20px;
+  grid-template-columns: auto 1fr;
+`;
+
+const Loading = styled(LoadingBar)`
+  width: 100%;
+`;

--- a/packages/client/src/layers/react/components/common/LoadingBar.tsx
+++ b/packages/client/src/layers/react/components/common/LoadingBar.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+import styled from "styled-components";
+
+export const LoadingBar: React.FC<{ percentage: number; className?: string }> = ({ percentage, className }) => {
+  return (
+    <Wrapper className={className}>
+      <Inner percentage={percentage} />
+    </Wrapper>
+  );
+};
+
+const Wrapper = styled.div`
+  position: relative;
+  height: 4px;
+  background-color: #2a2a2a;
+`;
+const Inner = styled.div<{ percentage: number }>`
+  height: 100%;
+  width: ${(p) => p.percentage}%;
+  background-color: #fff;
+  transition: all 300ms ease;
+`;

--- a/packages/client/src/layers/react/components/common/index.ts
+++ b/packages/client/src/layers/react/components/common/index.ts
@@ -6,6 +6,7 @@ export { AbsoluteBorder } from "./AbsoluteBorder";
 export { Crafting } from "./Crafting";
 export { Container, CloseableContainer } from "./Container";
 export { Button } from "./Button";
+export { LoadingBar } from "./LoadingBar";
 
 export const GUI = styled.div<{ _x: number; _y: number; _height: number; _width: number; scale: number }>`
   height: ${(p) => p._height * p.scale}px;

--- a/packages/client/src/layers/react/engine/components/BootScreen.tsx
+++ b/packages/client/src/layers/react/engine/components/BootScreen.tsx
@@ -9,7 +9,9 @@ export const BootScreen: React.FC<{ initialOpacity?: number }> = ({ children, in
   return (
     <Container>
       <img src="/img/opcraft-light.png" style={{ opacity, width: 300 }}></img>
-      <div>{children || <>&nbsp;</>}</div>
+      <div>
+        <>{children || <>&nbsp;</>}</>
+      </div>
     </Container>
   );
 };


### PR DESCRIPTION
- Increase `cacheAgeThreshold` from 100 to 600 (meaning cache is invalidated after 10 minutes)
- decrease cache storing interval to once every 100 blocks
- display a loading bar in the loading screen